### PR TITLE
Implement "non-blocking" Mojo::UserAgent behavior

### DIFF
--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -10,12 +10,16 @@ RUN cpanm Digest::SHA Module::Signature
 # reinstall cpanm itself, for good measure
 RUN cpanm App::cpanminus
 
-RUN cpanm Mojolicious@5.80
-
 RUN cpanm EV
 RUN cpanm IO::Socket::IP
 RUN cpanm --notest IO::Socket::SSL
 # the tests for IO::Socket::SSL like to hang... :(
+
+RUN cpanm Mojolicious@6.66
+
+# http://mojolicious.org/perldoc/Mojolicious/Guides/FAQ#What-does-Inactivity-timeout-mean
+ENV MOJO_INACTIVITY_TIMEOUT 120
+# The Hub takes a while to respond, and the time it takes to respond increases as we stack up more pending requests. :)
 
 COPY .remote.pl /usr/local/bin/remote.pl
 ENTRYPOINT ["remote.pl"]


### PR DESCRIPTION
This allows for natural parallelism to occur, which dramatically speeds up the metadata generation process.

On my local machine, before this change it takes roughly 29 minutes to do a full `update-remote.sh` run.  After this change, it takes roughly 15 minutes.

Fixes #6