### PR TITLE
Add "Virtual Size" to local display

### DIFF
--- a/scan-local.sh
+++ b/scan-local.sh
@@ -22,11 +22,30 @@ docker run -d --name "$name" --volumes-from "$name-data" repo-info:local > /dev/
 
 echo '# `'"$image"'`'
 
+size="$(
+	docker inspect -f '{{ .VirtualSize }}' "$image" | awk '{
+		oneKb = 1000;
+		oneMb = 1000 * oneKb;
+		oneGb = 1000 * oneMb;
+		if ($1 >= oneGb) {
+			printf "~ %.2f Gb", $1 / oneGb
+		} else if ($1 >= oneMb) {
+			printf "~ %.2f Mb", $1 / oneMb
+		} else if ($1 >= oneKb) {
+			printf "~ %.2f Kb", $1 / oneKb
+		} else {
+			printf "%d bytes", $1
+		}
+	}'
+)"
+
 docker inspect -f '
 ## Docker Metadata
 
 - Image ID: `{{ .Id }}`
 - Created: `{{ .Created }}`
+- Virtual Size: '"$size"'  
+  (total size of all layers on-disk)
 - Arch: `{{ .Os }}`/`{{ .Architecture }}`
 {{ if .Config.Entrypoint }}- Entrypoint: `{{ json .Config.Entrypoint }}`
 {{ end }}{{ if .Config.Cmd }}- Command: `{{ json .Config.Cmd }}`


### PR DESCRIPTION
The format is a bit lame because we're using `docker inspect`'s formatting directly and thus don't have an easy way to print this in a nice way (KB, MB, etc), but it's a start.