### PR TITLE
Add new "generate-readme.sh" script for generating a stub README for each repo, and invoke it during "update-remote"

### DIFF
--- a/generate-readme.sh
+++ b/generate-readme.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+repo="$1"; shift
+repoMd='`'"$repo"'`'
+
+cat <<EOF
+# $repoMd repo-info
+
+This directory contains additional information about the published artifacts of the $repoMd official image.
+
+-	[the \`remote\` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the \`local\` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.
+EOF

--- a/repos/adminer/README.md
+++ b/repos/adminer/README.md
@@ -1,0 +1,15 @@
+# `adminer` repo-info
+
+This directory contains additional information about the published artifacts of the `adminer` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/aerospike/README.md
+++ b/repos/aerospike/README.md
@@ -1,0 +1,15 @@
+# `aerospike` repo-info
+
+This directory contains additional information about the published artifacts of the `aerospike` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/alpine/README.md
+++ b/repos/alpine/README.md
@@ -1,0 +1,15 @@
+# `alpine` repo-info
+
+This directory contains additional information about the published artifacts of the `alpine` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/amazonlinux/README.md
+++ b/repos/amazonlinux/README.md
@@ -1,0 +1,15 @@
+# `amazonlinux` repo-info
+
+This directory contains additional information about the published artifacts of the `amazonlinux` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/arangodb/README.md
+++ b/repos/arangodb/README.md
@@ -1,0 +1,15 @@
+# `arangodb` repo-info
+
+This directory contains additional information about the published artifacts of the `arangodb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/backdrop/README.md
+++ b/repos/backdrop/README.md
@@ -1,0 +1,15 @@
+# `backdrop` repo-info
+
+This directory contains additional information about the published artifacts of the `backdrop` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/bash/README.md
+++ b/repos/bash/README.md
@@ -1,0 +1,15 @@
+# `bash` repo-info
+
+This directory contains additional information about the published artifacts of the `bash` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/bonita/README.md
+++ b/repos/bonita/README.md
@@ -1,0 +1,15 @@
+# `bonita` repo-info
+
+This directory contains additional information about the published artifacts of the `bonita` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/buildpack-deps/README.md
+++ b/repos/buildpack-deps/README.md
@@ -1,0 +1,15 @@
+# `buildpack-deps` repo-info
+
+This directory contains additional information about the published artifacts of the `buildpack-deps` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/busybox/README.md
+++ b/repos/busybox/README.md
@@ -1,0 +1,15 @@
+# `busybox` repo-info
+
+This directory contains additional information about the published artifacts of the `busybox` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/cassandra/README.md
+++ b/repos/cassandra/README.md
@@ -1,0 +1,15 @@
+# `cassandra` repo-info
+
+This directory contains additional information about the published artifacts of the `cassandra` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/celery/README.md
+++ b/repos/celery/README.md
@@ -1,0 +1,15 @@
+# `celery` repo-info
+
+This directory contains additional information about the published artifacts of the `celery` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/centos/README.md
+++ b/repos/centos/README.md
@@ -1,0 +1,15 @@
+# `centos` repo-info
+
+This directory contains additional information about the published artifacts of the `centos` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/chronograf/README.md
+++ b/repos/chronograf/README.md
@@ -1,0 +1,15 @@
+# `chronograf` repo-info
+
+This directory contains additional information about the published artifacts of the `chronograf` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/cirros/README.md
+++ b/repos/cirros/README.md
@@ -1,0 +1,15 @@
+# `cirros` repo-info
+
+This directory contains additional information about the published artifacts of the `cirros` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/clearlinux/README.md
+++ b/repos/clearlinux/README.md
@@ -1,0 +1,15 @@
+# `clearlinux` repo-info
+
+This directory contains additional information about the published artifacts of the `clearlinux` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/clojure/README.md
+++ b/repos/clojure/README.md
@@ -1,0 +1,15 @@
+# `clojure` repo-info
+
+This directory contains additional information about the published artifacts of the `clojure` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/composer/README.md
+++ b/repos/composer/README.md
@@ -1,0 +1,15 @@
+# `composer` repo-info
+
+This directory contains additional information about the published artifacts of the `composer` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/consul/README.md
+++ b/repos/consul/README.md
@@ -1,0 +1,15 @@
+# `consul` repo-info
+
+This directory contains additional information about the published artifacts of the `consul` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/convertigo/README.md
+++ b/repos/convertigo/README.md
@@ -1,0 +1,15 @@
+# `convertigo` repo-info
+
+This directory contains additional information about the published artifacts of the `convertigo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/couchbase/README.md
+++ b/repos/couchbase/README.md
@@ -1,0 +1,15 @@
+# `couchbase` repo-info
+
+This directory contains additional information about the published artifacts of the `couchbase` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/couchdb/README.md
+++ b/repos/couchdb/README.md
@@ -1,0 +1,15 @@
+# `couchdb` repo-info
+
+This directory contains additional information about the published artifacts of the `couchdb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/crate/README.md
+++ b/repos/crate/README.md
@@ -1,0 +1,15 @@
+# `crate` repo-info
+
+This directory contains additional information about the published artifacts of the `crate` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/crux/README.md
+++ b/repos/crux/README.md
@@ -1,0 +1,15 @@
+# `crux` repo-info
+
+This directory contains additional information about the published artifacts of the `crux` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/debian/README.md
+++ b/repos/debian/README.md
@@ -1,0 +1,15 @@
+# `debian` repo-info
+
+This directory contains additional information about the published artifacts of the `debian` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/django/README.md
+++ b/repos/django/README.md
@@ -1,0 +1,15 @@
+# `django` repo-info
+
+This directory contains additional information about the published artifacts of the `django` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/docker/README.md
+++ b/repos/docker/README.md
@@ -1,0 +1,15 @@
+# `docker` repo-info
+
+This directory contains additional information about the published artifacts of the `docker` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/drupal/README.md
+++ b/repos/drupal/README.md
@@ -1,0 +1,15 @@
+# `drupal` repo-info
+
+This directory contains additional information about the published artifacts of the `drupal` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/eclipse-mosquitto/README.md
+++ b/repos/eclipse-mosquitto/README.md
@@ -1,0 +1,15 @@
+# `eclipse-mosquitto` repo-info
+
+This directory contains additional information about the published artifacts of the `eclipse-mosquitto` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/eggdrop/README.md
+++ b/repos/eggdrop/README.md
@@ -1,0 +1,15 @@
+# `eggdrop` repo-info
+
+This directory contains additional information about the published artifacts of the `eggdrop` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/elasticsearch/README.md
+++ b/repos/elasticsearch/README.md
@@ -1,0 +1,15 @@
+# `elasticsearch` repo-info
+
+This directory contains additional information about the published artifacts of the `elasticsearch` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/elixir/README.md
+++ b/repos/elixir/README.md
@@ -1,0 +1,15 @@
+# `elixir` repo-info
+
+This directory contains additional information about the published artifacts of the `elixir` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/erlang/README.md
+++ b/repos/erlang/README.md
@@ -1,0 +1,15 @@
+# `erlang` repo-info
+
+This directory contains additional information about the published artifacts of the `erlang` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/fedora/README.md
+++ b/repos/fedora/README.md
@@ -1,0 +1,15 @@
+# `fedora` repo-info
+
+This directory contains additional information about the published artifacts of the `fedora` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/fsharp/README.md
+++ b/repos/fsharp/README.md
@@ -1,0 +1,15 @@
+# `fsharp` repo-info
+
+This directory contains additional information about the published artifacts of the `fsharp` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/gazebo/README.md
+++ b/repos/gazebo/README.md
@@ -1,0 +1,15 @@
+# `gazebo` repo-info
+
+This directory contains additional information about the published artifacts of the `gazebo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/gcc/README.md
+++ b/repos/gcc/README.md
@@ -1,0 +1,15 @@
+# `gcc` repo-info
+
+This directory contains additional information about the published artifacts of the `gcc` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/geonetwork/README.md
+++ b/repos/geonetwork/README.md
@@ -1,0 +1,15 @@
+# `geonetwork` repo-info
+
+This directory contains additional information about the published artifacts of the `geonetwork` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/ghost/README.md
+++ b/repos/ghost/README.md
@@ -1,0 +1,15 @@
+# `ghost` repo-info
+
+This directory contains additional information about the published artifacts of the `ghost` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/glassfish/README.md
+++ b/repos/glassfish/README.md
@@ -1,0 +1,15 @@
+# `glassfish` repo-info
+
+This directory contains additional information about the published artifacts of the `glassfish` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/golang/README.md
+++ b/repos/golang/README.md
@@ -1,0 +1,15 @@
+# `golang` repo-info
+
+This directory contains additional information about the published artifacts of the `golang` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/gradle/README.md
+++ b/repos/gradle/README.md
@@ -1,0 +1,15 @@
+# `gradle` repo-info
+
+This directory contains additional information about the published artifacts of the `gradle` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/groovy/README.md
+++ b/repos/groovy/README.md
@@ -1,0 +1,15 @@
+# `groovy` repo-info
+
+This directory contains additional information about the published artifacts of the `groovy` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/haproxy/README.md
+++ b/repos/haproxy/README.md
@@ -1,0 +1,15 @@
+# `haproxy` repo-info
+
+This directory contains additional information about the published artifacts of the `haproxy` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/haskell/README.md
+++ b/repos/haskell/README.md
@@ -1,0 +1,15 @@
+# `haskell` repo-info
+
+This directory contains additional information about the published artifacts of the `haskell` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/haxe/README.md
+++ b/repos/haxe/README.md
@@ -1,0 +1,15 @@
+# `haxe` repo-info
+
+This directory contains additional information about the published artifacts of the `haxe` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/hello-seattle/README.md
+++ b/repos/hello-seattle/README.md
@@ -1,0 +1,15 @@
+# `hello-seattle` repo-info
+
+This directory contains additional information about the published artifacts of the `hello-seattle` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/hello-world/README.md
+++ b/repos/hello-world/README.md
@@ -1,0 +1,15 @@
+# `hello-world` repo-info
+
+This directory contains additional information about the published artifacts of the `hello-world` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/hipache/README.md
+++ b/repos/hipache/README.md
@@ -1,0 +1,15 @@
+# `hipache` repo-info
+
+This directory contains additional information about the published artifacts of the `hipache` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/hola-mundo/README.md
+++ b/repos/hola-mundo/README.md
@@ -1,0 +1,15 @@
+# `hola-mundo` repo-info
+
+This directory contains additional information about the published artifacts of the `hola-mundo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/httpd/README.md
+++ b/repos/httpd/README.md
@@ -1,0 +1,15 @@
+# `httpd` repo-info
+
+This directory contains additional information about the published artifacts of the `httpd` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/hylang/README.md
+++ b/repos/hylang/README.md
@@ -1,0 +1,15 @@
+# `hylang` repo-info
+
+This directory contains additional information about the published artifacts of the `hylang` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/ibmjava/README.md
+++ b/repos/ibmjava/README.md
@@ -1,0 +1,15 @@
+# `ibmjava` repo-info
+
+This directory contains additional information about the published artifacts of the `ibmjava` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/influxdb/README.md
+++ b/repos/influxdb/README.md
@@ -1,0 +1,15 @@
+# `influxdb` repo-info
+
+This directory contains additional information about the published artifacts of the `influxdb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/iojs/README.md
+++ b/repos/iojs/README.md
@@ -1,0 +1,15 @@
+# `iojs` repo-info
+
+This directory contains additional information about the published artifacts of the `iojs` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/irssi/README.md
+++ b/repos/irssi/README.md
@@ -1,0 +1,15 @@
+# `irssi` repo-info
+
+This directory contains additional information about the published artifacts of the `irssi` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/java/README.md
+++ b/repos/java/README.md
@@ -1,0 +1,15 @@
+# `java` repo-info
+
+This directory contains additional information about the published artifacts of the `java` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/jenkins/README.md
+++ b/repos/jenkins/README.md
@@ -1,0 +1,15 @@
+# `jenkins` repo-info
+
+This directory contains additional information about the published artifacts of the `jenkins` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/jetty/README.md
+++ b/repos/jetty/README.md
@@ -1,0 +1,15 @@
+# `jetty` repo-info
+
+This directory contains additional information about the published artifacts of the `jetty` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/joomla/README.md
+++ b/repos/joomla/README.md
@@ -1,0 +1,15 @@
+# `joomla` repo-info
+
+This directory contains additional information about the published artifacts of the `joomla` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/jruby/README.md
+++ b/repos/jruby/README.md
@@ -1,0 +1,15 @@
+# `jruby` repo-info
+
+This directory contains additional information about the published artifacts of the `jruby` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/julia/README.md
+++ b/repos/julia/README.md
@@ -1,0 +1,15 @@
+# `julia` repo-info
+
+This directory contains additional information about the published artifacts of the `julia` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/kaazing-gateway/README.md
+++ b/repos/kaazing-gateway/README.md
@@ -1,0 +1,15 @@
+# `kaazing-gateway` repo-info
+
+This directory contains additional information about the published artifacts of the `kaazing-gateway` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/kapacitor/README.md
+++ b/repos/kapacitor/README.md
@@ -1,0 +1,15 @@
+# `kapacitor` repo-info
+
+This directory contains additional information about the published artifacts of the `kapacitor` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/kibana/README.md
+++ b/repos/kibana/README.md
@@ -1,0 +1,15 @@
+# `kibana` repo-info
+
+This directory contains additional information about the published artifacts of the `kibana` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/known/README.md
+++ b/repos/known/README.md
@@ -1,0 +1,15 @@
+# `known` repo-info
+
+This directory contains additional information about the published artifacts of the `known` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/kong/README.md
+++ b/repos/kong/README.md
@@ -1,0 +1,15 @@
+# `kong` repo-info
+
+This directory contains additional information about the published artifacts of the `kong` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/lightstreamer/README.md
+++ b/repos/lightstreamer/README.md
@@ -1,0 +1,15 @@
+# `lightstreamer` repo-info
+
+This directory contains additional information about the published artifacts of the `lightstreamer` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/logstash/README.md
+++ b/repos/logstash/README.md
@@ -1,0 +1,15 @@
+# `logstash` repo-info
+
+This directory contains additional information about the published artifacts of the `logstash` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mageia/README.md
+++ b/repos/mageia/README.md
@@ -1,0 +1,15 @@
+# `mageia` repo-info
+
+This directory contains additional information about the published artifacts of the `mageia` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mariadb/README.md
+++ b/repos/mariadb/README.md
@@ -1,0 +1,15 @@
+# `mariadb` repo-info
+
+This directory contains additional information about the published artifacts of the `mariadb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/maven/README.md
+++ b/repos/maven/README.md
@@ -1,0 +1,15 @@
+# `maven` repo-info
+
+This directory contains additional information about the published artifacts of the `maven` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/memcached/README.md
+++ b/repos/memcached/README.md
@@ -1,0 +1,15 @@
+# `memcached` repo-info
+
+This directory contains additional information about the published artifacts of the `memcached` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mongo-express/README.md
+++ b/repos/mongo-express/README.md
@@ -1,0 +1,15 @@
+# `mongo-express` repo-info
+
+This directory contains additional information about the published artifacts of the `mongo-express` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mongo/README.md
+++ b/repos/mongo/README.md
@@ -1,0 +1,15 @@
+# `mongo` repo-info
+
+This directory contains additional information about the published artifacts of the `mongo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mono/README.md
+++ b/repos/mono/README.md
@@ -1,0 +1,15 @@
+# `mono` repo-info
+
+This directory contains additional information about the published artifacts of the `mono` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/mysql/README.md
+++ b/repos/mysql/README.md
@@ -1,0 +1,15 @@
+# `mysql` repo-info
+
+This directory contains additional information about the published artifacts of the `mysql` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/nats-streaming/README.md
+++ b/repos/nats-streaming/README.md
@@ -1,0 +1,15 @@
+# `nats-streaming` repo-info
+
+This directory contains additional information about the published artifacts of the `nats-streaming` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/nats/README.md
+++ b/repos/nats/README.md
@@ -1,0 +1,15 @@
+# `nats` repo-info
+
+This directory contains additional information about the published artifacts of the `nats` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/neo4j/README.md
+++ b/repos/neo4j/README.md
@@ -1,0 +1,15 @@
+# `neo4j` repo-info
+
+This directory contains additional information about the published artifacts of the `neo4j` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/neurodebian/README.md
+++ b/repos/neurodebian/README.md
@@ -1,0 +1,15 @@
+# `neurodebian` repo-info
+
+This directory contains additional information about the published artifacts of the `neurodebian` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/nextcloud/README.md
+++ b/repos/nextcloud/README.md
@@ -1,0 +1,15 @@
+# `nextcloud` repo-info
+
+This directory contains additional information about the published artifacts of the `nextcloud` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/nginx/README.md
+++ b/repos/nginx/README.md
@@ -1,0 +1,15 @@
+# `nginx` repo-info
+
+This directory contains additional information about the published artifacts of the `nginx` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/node/README.md
+++ b/repos/node/README.md
@@ -1,0 +1,15 @@
+# `node` repo-info
+
+This directory contains additional information about the published artifacts of the `node` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/notary/README.md
+++ b/repos/notary/README.md
@@ -1,0 +1,15 @@
+# `notary` repo-info
+
+This directory contains additional information about the published artifacts of the `notary` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/nuxeo/README.md
+++ b/repos/nuxeo/README.md
@@ -1,0 +1,15 @@
+# `nuxeo` repo-info
+
+This directory contains additional information about the published artifacts of the `nuxeo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/odoo/README.md
+++ b/repos/odoo/README.md
@@ -1,0 +1,15 @@
+# `odoo` repo-info
+
+This directory contains additional information about the published artifacts of the `odoo` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/openjdk/README.md
+++ b/repos/openjdk/README.md
@@ -1,0 +1,15 @@
+# `openjdk` repo-info
+
+This directory contains additional information about the published artifacts of the `openjdk` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/opensuse/README.md
+++ b/repos/opensuse/README.md
@@ -1,0 +1,15 @@
+# `opensuse` repo-info
+
+This directory contains additional information about the published artifacts of the `opensuse` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/oraclelinux/README.md
+++ b/repos/oraclelinux/README.md
@@ -1,0 +1,15 @@
+# `oraclelinux` repo-info
+
+This directory contains additional information about the published artifacts of the `oraclelinux` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/orientdb/README.md
+++ b/repos/orientdb/README.md
@@ -1,0 +1,15 @@
+# `orientdb` repo-info
+
+This directory contains additional information about the published artifacts of the `orientdb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/owncloud/README.md
+++ b/repos/owncloud/README.md
@@ -1,0 +1,15 @@
+# `owncloud` repo-info
+
+This directory contains additional information about the published artifacts of the `owncloud` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/percona/README.md
+++ b/repos/percona/README.md
@@ -1,0 +1,15 @@
+# `percona` repo-info
+
+This directory contains additional information about the published artifacts of the `percona` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/perl/README.md
+++ b/repos/perl/README.md
@@ -1,0 +1,15 @@
+# `perl` repo-info
+
+This directory contains additional information about the published artifacts of the `perl` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/photon/README.md
+++ b/repos/photon/README.md
@@ -1,0 +1,15 @@
+# `photon` repo-info
+
+This directory contains additional information about the published artifacts of the `photon` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/php-zendserver/README.md
+++ b/repos/php-zendserver/README.md
@@ -1,0 +1,15 @@
+# `php-zendserver` repo-info
+
+This directory contains additional information about the published artifacts of the `php-zendserver` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/php/README.md
+++ b/repos/php/README.md
@@ -1,0 +1,15 @@
+# `php` repo-info
+
+This directory contains additional information about the published artifacts of the `php` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/piwik/README.md
+++ b/repos/piwik/README.md
@@ -1,0 +1,15 @@
+# `piwik` repo-info
+
+This directory contains additional information about the published artifacts of the `piwik` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/plone/README.md
+++ b/repos/plone/README.md
@@ -1,0 +1,15 @@
+# `plone` repo-info
+
+This directory contains additional information about the published artifacts of the `plone` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/postgres/README.md
+++ b/repos/postgres/README.md
@@ -1,0 +1,15 @@
+# `postgres` repo-info
+
+This directory contains additional information about the published artifacts of the `postgres` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/pypy/README.md
+++ b/repos/pypy/README.md
@@ -1,0 +1,15 @@
+# `pypy` repo-info
+
+This directory contains additional information about the published artifacts of the `pypy` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/python/README.md
+++ b/repos/python/README.md
@@ -1,0 +1,15 @@
+# `python` repo-info
+
+This directory contains additional information about the published artifacts of the `python` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/r-base/README.md
+++ b/repos/r-base/README.md
@@ -1,0 +1,15 @@
+# `r-base` repo-info
+
+This directory contains additional information about the published artifacts of the `r-base` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rabbitmq/README.md
+++ b/repos/rabbitmq/README.md
@@ -1,0 +1,15 @@
+# `rabbitmq` repo-info
+
+This directory contains additional information about the published artifacts of the `rabbitmq` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rails/README.md
+++ b/repos/rails/README.md
@@ -1,0 +1,15 @@
+# `rails` repo-info
+
+This directory contains additional information about the published artifacts of the `rails` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rakudo-star/README.md
+++ b/repos/rakudo-star/README.md
@@ -1,0 +1,15 @@
+# `rakudo-star` repo-info
+
+This directory contains additional information about the published artifacts of the `rakudo-star` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rapidoid/README.md
+++ b/repos/rapidoid/README.md
@@ -1,0 +1,15 @@
+# `rapidoid` repo-info
+
+This directory contains additional information about the published artifacts of the `rapidoid` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/redis/README.md
+++ b/repos/redis/README.md
@@ -1,0 +1,15 @@
+# `redis` repo-info
+
+This directory contains additional information about the published artifacts of the `redis` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/redmine/README.md
+++ b/repos/redmine/README.md
@@ -1,0 +1,15 @@
+# `redmine` repo-info
+
+This directory contains additional information about the published artifacts of the `redmine` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/registry/README.md
+++ b/repos/registry/README.md
@@ -1,0 +1,15 @@
+# `registry` repo-info
+
+This directory contains additional information about the published artifacts of the `registry` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rethinkdb/README.md
+++ b/repos/rethinkdb/README.md
@@ -1,0 +1,15 @@
+# `rethinkdb` repo-info
+
+This directory contains additional information about the published artifacts of the `rethinkdb` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/rocket.chat/README.md
+++ b/repos/rocket.chat/README.md
@@ -1,0 +1,15 @@
+# `rocket.chat` repo-info
+
+This directory contains additional information about the published artifacts of the `rocket.chat` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/ros/README.md
+++ b/repos/ros/README.md
@@ -1,0 +1,15 @@
+# `ros` repo-info
+
+This directory contains additional information about the published artifacts of the `ros` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/ruby/README.md
+++ b/repos/ruby/README.md
@@ -1,0 +1,15 @@
+# `ruby` repo-info
+
+This directory contains additional information about the published artifacts of the `ruby` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/sentry/README.md
+++ b/repos/sentry/README.md
@@ -1,0 +1,15 @@
+# `sentry` repo-info
+
+This directory contains additional information about the published artifacts of the `sentry` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/silverpeas/README.md
+++ b/repos/silverpeas/README.md
@@ -1,0 +1,15 @@
+# `silverpeas` repo-info
+
+This directory contains additional information about the published artifacts of the `silverpeas` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/solr/README.md
+++ b/repos/solr/README.md
@@ -1,0 +1,15 @@
+# `solr` repo-info
+
+This directory contains additional information about the published artifacts of the `solr` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/sonarqube/README.md
+++ b/repos/sonarqube/README.md
@@ -1,0 +1,15 @@
+# `sonarqube` repo-info
+
+This directory contains additional information about the published artifacts of the `sonarqube` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/sourcemage/README.md
+++ b/repos/sourcemage/README.md
@@ -1,0 +1,15 @@
+# `sourcemage` repo-info
+
+This directory contains additional information about the published artifacts of the `sourcemage` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/spiped/README.md
+++ b/repos/spiped/README.md
@@ -1,0 +1,15 @@
+# `spiped` repo-info
+
+This directory contains additional information about the published artifacts of the `spiped` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/storm/README.md
+++ b/repos/storm/README.md
@@ -1,0 +1,15 @@
+# `storm` repo-info
+
+This directory contains additional information about the published artifacts of the `storm` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/swarm/README.md
+++ b/repos/swarm/README.md
@@ -1,0 +1,15 @@
+# `swarm` repo-info
+
+This directory contains additional information about the published artifacts of the `swarm` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/swift/README.md
+++ b/repos/swift/README.md
@@ -1,0 +1,15 @@
+# `swift` repo-info
+
+This directory contains additional information about the published artifacts of the `swift` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/telegraf/README.md
+++ b/repos/telegraf/README.md
@@ -1,0 +1,15 @@
+# `telegraf` repo-info
+
+This directory contains additional information about the published artifacts of the `telegraf` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/thrift/README.md
+++ b/repos/thrift/README.md
@@ -1,0 +1,15 @@
+# `thrift` repo-info
+
+This directory contains additional information about the published artifacts of the `thrift` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/tomcat/README.md
+++ b/repos/tomcat/README.md
@@ -1,0 +1,15 @@
+# `tomcat` repo-info
+
+This directory contains additional information about the published artifacts of the `tomcat` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/tomee/README.md
+++ b/repos/tomee/README.md
@@ -1,0 +1,15 @@
+# `tomee` repo-info
+
+This directory contains additional information about the published artifacts of the `tomee` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/traefik/README.md
+++ b/repos/traefik/README.md
@@ -1,0 +1,15 @@
+# `traefik` repo-info
+
+This directory contains additional information about the published artifacts of the `traefik` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/ubuntu/README.md
+++ b/repos/ubuntu/README.md
@@ -1,0 +1,15 @@
+# `ubuntu` repo-info
+
+This directory contains additional information about the published artifacts of the `ubuntu` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/vault/README.md
+++ b/repos/vault/README.md
@@ -1,0 +1,15 @@
+# `vault` repo-info
+
+This directory contains additional information about the published artifacts of the `vault` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/websphere-liberty/README.md
+++ b/repos/websphere-liberty/README.md
@@ -1,0 +1,15 @@
+# `websphere-liberty` repo-info
+
+This directory contains additional information about the published artifacts of the `websphere-liberty` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/wordpress/README.md
+++ b/repos/wordpress/README.md
@@ -1,0 +1,15 @@
+# `wordpress` repo-info
+
+This directory contains additional information about the published artifacts of the `wordpress` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/xwiki/README.md
+++ b/repos/xwiki/README.md
@@ -1,0 +1,15 @@
+# `xwiki` repo-info
+
+This directory contains additional information about the published artifacts of the `xwiki` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/znc/README.md
+++ b/repos/znc/README.md
@@ -1,0 +1,15 @@
+# `znc` repo-info
+
+This directory contains additional information about the published artifacts of the `znc` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/repos/zookeeper/README.md
+++ b/repos/zookeeper/README.md
@@ -1,0 +1,15 @@
+# `zookeeper` repo-info
+
+This directory contains additional information about the published artifacts of the `zookeeper` official image.
+
+-	[the `remote` directory](remote/):
+
+	-	gathered from the Docker Hub/Registry API
+
+	-	image digests/blobs, transfer sizes, image metadata, etc.
+
+-	[the `local` directory](local/):
+
+	-	inspected from the image on-disk after it is pulled
+
+	-	installed packages, creation date, architecture, environment variables, detected licenses, etc.

--- a/update-remote.sh
+++ b/update-remote.sh
@@ -49,6 +49,7 @@ for repo in "${repos[@]}"; do
 	fi
 	rm -rf "repos/$repo/remote"
 	mkdir -p "repos/$repo/remote"
+	./generate-readme.sh "$repo" > "repos/$repo/README.md"
 	{
 		echo "<!-- THIS FILE IS GENERATED VIA '$0' -->"
 		echo


### PR DESCRIPTION
This is the first part of the improved solution to https://github.com/docker-library/docs/pull/687.