### PR TITLE
Replace "bashbrew list" with a "bashbrew cat" that includes SharedTags

### DIFF
--- a/update-remote.sh
+++ b/update-remote.sh
@@ -41,7 +41,7 @@ echo 'done'
 for repo in "${repos[@]}"; do
 	echo -n "$repo ... "
 	IFS=$'\n'
-	tags=( $(bashbrew list "$repo" 2>/dev/null || true) )
+	tags=( $(bashbrew cat --format '{{- range .Entries -}}{{- range .Tags -}}{{- $.RepoName -}}:{{- . -}}{{- "\n" -}}{{- end -}}{{- range .SharedTags -}}{{- $.RepoName -}}:{{- . -}}{{- "\n" -}}{{- end -}}{{- end -}}' "$repo" 2>/dev/null | sort -u) )
 	unset IFS
 	if [ "${#tags[@]}" -eq 0 ]; then
 		echo 'skipping'


### PR DESCRIPTION
This will create `repos/hello-world/remote/latest.md`, which will include both `linux` _and_ `windows` tags in the same markdown. :metal: