### PR TITLE
Convert ".remote.pl" to use "Mojo::Promise" instead of callback chaining

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .dockerignore
-.git
+.git*
 Dockerfile*
+repos/

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -1,4 +1,4 @@
-FROM perl:5.20
+FROM perl:5.28
 
 # secure by default ♥ (thanks to sri!)
 ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org
@@ -22,7 +22,7 @@ RUN cpanm --notest IO::Socket::SSL
 ENV LIBEV_FLAGS 4
 # epoll (Linux)
 
-RUN cpanm Mojolicious@7.94
+RUN cpanm Mojolicious@8.13
 
 # http://mojolicious.org/perldoc/Mojolicious/Guides/FAQ#What-does-Inactivity-timeout-mean
 ENV MOJO_INACTIVITY_TIMEOUT 120

--- a/update-remote.sh
+++ b/update-remote.sh
@@ -20,11 +20,11 @@ docker run -d --name repo-info-remote repo-info:remote daemon > /dev/null
 
 trap 'err="$?"; echo >&2 "ERROR: exit code $err"; ( set -x && docker logs repo-info-remote ); exit "$err"' ERR
 
-repoInfoDaemon='http://localhost:3000' # since we're using "docker exec", we can just hit localhost
-curl=( docker exec -i repo-info-remote curl -fsSL )
+export repoInfoDaemon='http://localhost:3000' # since we're using "docker exec", we can just hit localhost
+export curl='docker exec -i repo-info-remote curl -fsSL'
 
 tries=10
-while [ "$("${curl[@]}" --max-time 2 "$repoInfoDaemon" -o /dev/null &> /dev/null || echo "$?")" = '7' ]; do
+while [ "$($curl --max-time 2 "$repoInfoDaemon" -o /dev/null &> /dev/null || echo "$?")" = '7' ]; do
 	(( --tries )) || :
 	if [ "$tries" -eq 0 ]; then
 		echo >&2 "error: repo-info:remote daemon did not start up in a reasonable amount of time"
@@ -33,44 +33,38 @@ while [ "$("${curl[@]}" --max-time 2 "$repoInfoDaemon" -o /dev/null &> /dev/null
 	sleep 1
 done
 
-# use "xargs" parallelism to pre-fill our new daemon's cache a bit (which should help speed things up in the long run)
-echo -n 'pre-filling cache ... '
-bashbrew list --repos "${repos[@]}" 2>/dev/null \
-	| sed 's!^!'"$repoInfoDaemon"'/markdown/!' \
-	| xargs -n 1 -P "${PARALLELISM:-4}" "${curl[@]}" -o /dev/null
-echo 'done'
-
-for repo in "${repos[@]}"; do
-	echo -n "$repo ... "
-	IFS=$'\n'
-	tags=( $(bashbrew list "$repo" 2>/dev/null | sort -u) )
-	unset IFS
-	if [ "${#tags[@]}" -eq 0 ]; then
-		echo 'skipping'
-		continue
-	fi
-	rm -rf "repos/$repo/remote"
-	mkdir -p "repos/$repo/remote"
-	./generate-readme.sh "$repo" > "repos/$repo/README.md"
-	{
-		echo "<!-- THIS FILE IS GENERATED VIA '$0' -->"
-		echo
-		echo "# Tags of \`$repo\`"
-		echo
-		# add a simple ToC
-		for tag in "${tags[@]}"; do
-			# GitHub heading anchors are strange
-			href="${tag//./}"
-			href="${href//:/}"
-			href="#${href,,}"
-			echo $'-\t[`'"$tag"'`]('"$href"')'
+# use "xargs" for parallelism
+export generator="$0" tab=$'\t' quot="'"
+xargs <<<"${repos[*]}" -n 1 -P "${PARALLELISM:-8}" bash -Eeuo pipefail -c '
+	for repo; do
+		tags=( $(bashbrew list "$repo" 2>/dev/null | sort -u) )
+		if [ "${#tags[@]}" -eq 0 ]; then
+			echo "skip:   $repo"
+			continue
+		fi
+		rm -rf "repos/$repo/remote"
+		mkdir -p "repos/$repo/remote"
+		./generate-readme.sh "$repo" > "repos/$repo/README.md"
+		{
+			echo "<!-- THIS FILE IS GENERATED VIA $quot$generator$quot -->"
+			echo
+			echo "# Tags of \`$repo\`"
+			echo
+			# add a simple ToC
+			for tag in "${tags[@]}"; do
+				# GitHub heading anchors are strange
+				href="${tag//./}"
+				href="${href//:/}"
+				href="#${href,,}"
+				echo "-$tab[\`$tag\`]($href)"
 		done
 		# fetch each markdown
 		for tag in "${tags[@]}"; do
+			echo >&2 "processing: $tag"
 			echo
-			"${curl[@]}" "$repoInfoDaemon/markdown/$tag" \
+			$curl -fsSL "$repoInfoDaemon/markdown/$tag" \
 				| tee "repos/$repo/remote/${tag#*:}.md"
 		done
-	} > "repos/$repo/tag-details.md"
-	echo 'done'
-done
+		} > "repos/$repo/tag-details.md"
+	done
+' --


### PR DESCRIPTION
This doesn't really make things shorter, but IMO it increases readability a lot, especially in the `get_image_data_p` implementation (where the steps are finally listed in the order they happen again like they were back in the blocking version of this code).  It's honestly bothered me a *lot* that readability suffered so much when I converted this code to be non-blocking (back in db217e426ec7229c74f154953dbe2f3e9ad2e157), so this really makes me feel good. 👍

With these changes plus a few tweaks to how `update-remote.sh` parallelizes, I'm able to successfully regenerate the full set of all `repos/**/remote/` files in ~5.5m on my machine (Jenkins is currently taking ~30m, and it's slower so I imagine it'll take somewhere on the order of twice my machine's runtime so hopefully somewhere around ~10m but should definitely be less than ~30m even if we have to bump `PARALLELISM` back down).