### PR TITLE
Add very basic initial support for scraping some amount of information out of APK for Alpine-based images

### DIFF
--- a/.local-scripts/gather-apk.sh
+++ b/.local-scripts/gather-apk.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+_apk() {
+	apk --no-network "$@" 2>/dev/null
+}
+
+IFS=$'\n'
+packages=( $(_apk info | sort) )
+unset IFS
+
+if [ "${#packages[@]}" -eq 0 ]; then
+	# not Alpine-based?
+	exit 1
+fi
+
+echo
+echo '## `apk` (`.apk`-based packages)'
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+for pkg in "${packages[@]}"; do
+	if [ "${pkg#.}" != "$pkg" ]; then
+		# if package name starts with a period, it's a pretty strong indicator that it's likely a user-created virtual and thus safely ignored for the purposes of this report
+		continue
+	fi
+
+	echo
+	echo '### `apk` package: `'"$pkg"'`'
+
+	# TODO parse this output better somehow (can't find a way to get `apk info` to spit out just the value without the `xyz-VERSION license:` header)
+	echo
+	echo '```console'
+	_apk info \
+		--description \
+		--license \
+		--size \
+		--webpage \
+		"$pkg"
+	echo '```'
+done

--- a/.local-scripts/gather.sh
+++ b/.local-scripts/gather.sh
@@ -2,5 +2,6 @@
 set -e
 
 prep-env.sh
+gather-apk.sh || :
 gather-dpkg.sh || :
 gather-rpm.sh || :

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -13,6 +13,20 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+# Alpine-based images need "apk" for data extraction
+RUN set -eux; \
+# https://pkgs.alpinelinux.org/package/v3.9/main/x86_64/apk-tools-static
+	apkStaticDist='v3.9'; \
+	apkStaticVersion='2.10.3-r1'; \
+# TODO convert "dpkg --print-architecture" to Alpine architecture for downloading the correct architecture binary
+	apkStaticArch='x86_64'; \
+	apkStaticUrl="http://dl-cdn.alpinelinux.org/alpine/$apkStaticDist/main/$apkStaticArch/apk-tools-static-$apkStaticVersion.apk"; \
+	wget -O /tmp/apk-tools-static.apk "$apkStaticUrl"; \
+	tar -xzvf /tmp/apk-tools-static.apk -C /usr/local/ --wildcards '*bin/apk.static'; \
+	mv /usr/local/*bin/apk.static /usr/local/bin/apk; \
+	rm /tmp/apk-tools-static.apk; \
+	apk --version
+
 COPY .local-scripts/*.sh /usr/local/bin/
 
 CMD ["gather.sh"]

--- a/scan-local.sh
+++ b/scan-local.sh
@@ -13,7 +13,9 @@ trap "docker rm -f '$name-data' '$name' > /dev/null || :" EXIT
 docker create \
 	--name "$name-data" \
 	-v /etc \
+	-v /lib/apk \
 	-v /usr/lib/rpm \
+	-v /usr/share/apk \
 	-v /usr/share/doc \
 	-v /var/lib \
 	"$image" \


### PR DESCRIPTION
Example output from `s390x/bash`:

<details>

# `s390x/bash`

## Docker Metadata

- Image ID: `sha256:21eb9f6dead2a05c9a2e63a449b5ce3549f10604b04467e4593ffa166065ba35`
- Created: `2019-03-21T11:42:18.351960994Z`
- Virtual Size: ~ 15.97 Mb  
  (total size of all layers on-disk)
- Arch: `linux`/`s390x`
- Entrypoint: `["docker-entrypoint.sh"]`
- Command: `["bash"]`
- Environment:
  - `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
  - `_BASH_GPG_KEY=7C0135FB088AAF6C66C650B9BB5869F064EA74AB`
  - `_BASH_VERSION=5.0`
  - `_BASH_PATCH_LEVEL=0`
  - `_BASH_LATEST_PATCH=3`

## `apk` (`.apk`-based packages)

### `apk` package: `alpine-baselayout`

```console
alpine-baselayout-3.1.0-r3 description:
Alpine base dir structure and init scripts

alpine-baselayout-3.1.0-r3 webpage:
https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout

alpine-baselayout-3.1.0-r3 installed size:
401408

alpine-baselayout-3.1.0-r3 license:
GPL-2.0

```

### `apk` package: `alpine-keys`

```console
alpine-keys-2.1-r1 description:
Public keys for Alpine Linux packages

alpine-keys-2.1-r1 webpage:
http://alpinelinux.org

alpine-keys-2.1-r1 installed size:
90112

alpine-keys-2.1-r1 license:
MIT

```

### `apk` package: `apk-tools`

```console
apk-tools-2.10.3-r1 description:
Alpine Package Keeper - package manager for alpine

apk-tools-2.10.3-r1 webpage:
https://git.alpinelinux.org/cgit/apk-tools/

apk-tools-2.10.3-r1 installed size:
303104

apk-tools-2.10.3-r1 license:
GPL2

```

### `apk` package: `busybox`

```console
busybox-1.29.3-r10 description:
Size optimized toolbox of many common UNIX utilities

busybox-1.29.3-r10 webpage:
http://busybox.net

busybox-1.29.3-r10 installed size:
1073152

busybox-1.29.3-r10 license:
GPL-2.0

```

### `apk` package: `ca-certificates-cacert`

```console
ca-certificates-cacert-20190108-r0 description:
Mozilla bundled certificates

ca-certificates-cacert-20190108-r0 webpage:
https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/

ca-certificates-cacert-20190108-r0 installed size:
245760

ca-certificates-cacert-20190108-r0 license:
MPL-2.0 GPL-2.0-or-later

```

### `apk` package: `libc-utils`

```console
libc-utils-0.7.1-r0 description:
Meta package to pull in correct libc

libc-utils-0.7.1-r0 webpage:
http://alpinelinux.org

libc-utils-0.7.1-r0 installed size:
4096

libc-utils-0.7.1-r0 license:
BSD

```

### `apk` package: `libcrypto1.1`

```console
libcrypto1.1-1.1.1a-r1 description:
Crypto library from openssl

libcrypto1.1-1.1.1a-r1 webpage:
https://www.openssl.org

libcrypto1.1-1.1.1a-r1 installed size:
2441216

libcrypto1.1-1.1.1a-r1 license:
OpenSSL

```

### `apk` package: `libssl1.1`

```console
libssl1.1-1.1.1a-r1 description:
SSL shared libraries

libssl1.1-1.1.1a-r1 webpage:
https://www.openssl.org

libssl1.1-1.1.1a-r1 installed size:
585728

libssl1.1-1.1.1a-r1 license:
OpenSSL

```

### `apk` package: `libtls-standalone`

```console
libtls-standalone-2.7.4-r6 description:
libtls extricated from libressl sources

libtls-standalone-2.7.4-r6 webpage:
http://www.libressl.org/

libtls-standalone-2.7.4-r6 installed size:
131072

libtls-standalone-2.7.4-r6 license:
ISC

```

### `apk` package: `musl`

```console
musl-1.1.20-r4 description:
the musl c library (libc) implementation

musl-1.1.20-r4 webpage:
http://www.musl-libc.org/

musl-1.1.20-r4 installed size:
688128

musl-1.1.20-r4 license:
MIT

```

### `apk` package: `musl-utils`

```console
musl-utils-1.1.20-r4 description:
the musl c library (libc) implementation

musl-utils-1.1.20-r4 webpage:
http://www.musl-libc.org/

musl-utils-1.1.20-r4 installed size:
131072

musl-utils-1.1.20-r4 license:
MIT BSD GPL2+

```

### `apk` package: `ncurses-libs`

```console
ncurses-libs-6.1_p20190105-r0 description:
Ncurses libraries

ncurses-libs-6.1_p20190105-r0 webpage:
https://www.gnu.org/software/ncurses/

ncurses-libs-6.1_p20190105-r0 installed size:
544768

ncurses-libs-6.1_p20190105-r0 license:
MIT

```

### `apk` package: `ncurses-terminfo`

```console
ncurses-terminfo-6.1_p20190105-r0 description:
Console display library (other terminfo files)

ncurses-terminfo-6.1_p20190105-r0 webpage:
https://www.gnu.org/software/ncurses/

ncurses-terminfo-6.1_p20190105-r0 installed size:
7274496

ncurses-terminfo-6.1_p20190105-r0 license:
MIT

```

### `apk` package: `ncurses-terminfo-base`

```console
ncurses-terminfo-base-6.1_p20190105-r0 description:
Descriptions of common terminals

ncurses-terminfo-base-6.1_p20190105-r0 webpage:
https://www.gnu.org/software/ncurses/

ncurses-terminfo-base-6.1_p20190105-r0 installed size:
94208

ncurses-terminfo-base-6.1_p20190105-r0 license:
MIT

```

### `apk` package: `scanelf`

```console
scanelf-1.2.3-r0 description:
Scan ELF binaries for stuff

scanelf-1.2.3-r0 webpage:
https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities

scanelf-1.2.3-r0 installed size:
102400

scanelf-1.2.3-r0 license:
GPL-2.0

```

### `apk` package: `ssl_client`

```console
ssl_client-1.29.3-r10 description:
EXternal ssl_client for busybox wget

ssl_client-1.29.3-r10 webpage:
http://busybox.net

ssl_client-1.29.3-r10 installed size:
24576

ssl_client-1.29.3-r10 license:
GPL-2.0

```

### `apk` package: `zlib`

```console
zlib-1.2.11-r1 description:
A compression/decompression Library

zlib-1.2.11-r1 webpage:
http://zlib.net

zlib-1.2.11-r1 installed size:
110592

zlib-1.2.11-r1 license:
zlib

```

</details>