### PR TITLE
Use new "perl-bashbrew" library for registry interaction

### DIFF
--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -1,32 +1,9 @@
-FROM perl:5.28
+FROM oisupport/perl-bashbrew
 
-# secure by default ♥ (thanks to sri!)
-ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org
-# TODO find a way to make --mirror-only / SSL work with backpan too :(
-RUN cpanm Digest::SHA Module::Signature
-# TODO find a way to make --verify work with backpan as well :'(
-#ENV PERL_CPANM_OPT $PERL_CPANM_OPT --verify
-
-# reinstall cpanm itself, for good measure
-RUN cpanm App::cpanminus
-
-RUN cpanm EV
-RUN cpanm IO::Socket::IP
-RUN cpanm IO::Socket::Socks
-RUN cpanm Net::DNS::Native
-
-# the tests for IO::Socket::SSL like to hang... :(
-RUN cpanm --notest IO::Socket::SSL
-
-# https://metacpan.org/pod/release/SRI/Mojolicious-7.94/lib/Mojo/IOLoop.pm#DESCRIPTION
-ENV LIBEV_FLAGS 4
-# epoll (Linux)
-
-RUN cpanm Mojolicious@8.13
-
-# http://mojolicious.org/perldoc/Mojolicious/Guides/FAQ#What-does-Inactivity-timeout-mean
-ENV MOJO_INACTIVITY_TIMEOUT 120
-# The Hub takes a while to respond, and the time it takes to respond increases as we stack up more pending requests. :)
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends curl; \
+	rm -rf /var/lib/apt/lists/*
 
 COPY .remote.pl /usr/local/bin/remote.pl
 ENTRYPOINT ["remote.pl"]

--- a/update-remote.sh
+++ b/update-remote.sh
@@ -16,7 +16,7 @@ repos=( "${repos[@]%/}" )
 
 docker build --pull -t repo-info:remote -q -f Dockerfile.remote . > /dev/null
 trap 'docker rm -f repo-info-remote > /dev/null' EXIT
-docker run -d --name repo-info-remote repo-info:remote daemon > /dev/null
+docker run -e DOCKERHUB_PUBLIC_PROXY -d --name repo-info-remote repo-info:remote daemon > /dev/null
 
 trap 'err="$?"; echo >&2 "ERROR: exit code $err"; ( set -x && docker logs repo-info-remote ); exit "$err"' ERR
 
@@ -62,7 +62,7 @@ xargs <<<"${repos[*]}" -n 1 -P "${PARALLELISM:-8}" bash -Eeuo pipefail -c '
 		for tag in "${tags[@]}"; do
 			echo >&2 "processing: $tag"
 			echo
-			$curl -fsSL "$repoInfoDaemon/markdown/$tag" \
+			$curl "$repoInfoDaemon/markdown/$tag" \
 				| tee "repos/$repo/remote/${tag#*:}.md"
 		done
 		} > "repos/$repo/tag-details.md"


### PR DESCRIPTION
See https://github.com/docker-library/perl-bashbrew (built and pushed to https://hub.docker.com/r/oisupport/perl-bashbrew).

The most notable change is that this adds support for `DOCKERHUB_PUBLIC_PROXY` for speeding up the information gathering (or at least allowing for an external cache of information).