### PR TITLE
apk-tools-static version no longer on mirror

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -15,9 +15,9 @@ RUN set -eux; \
 
 # Alpine-based images need "apk" for data extraction
 RUN set -eux; \
-# https://pkgs.alpinelinux.org/package/v3.9/main/x86_64/apk-tools-static
-	apkStaticDist='v3.9'; \
-	apkStaticVersion='2.10.3-r1'; \
+# https://pkgs.alpinelinux.org/package/v3.13/main/x86_64/apk-tools-static
+	apkStaticDist='v3.13'; \
+	apkStaticVersion='2.12.5-r0'; \
 # TODO convert "dpkg --print-architecture" to Alpine architecture for downloading the correct architecture binary
 	apkStaticArch='x86_64'; \
 	apkStaticUrl="http://dl-cdn.alpinelinux.org/alpine/$apkStaticDist/main/$apkStaticArch/apk-tools-static-$apkStaticVersion.apk"; \


### PR DESCRIPTION
noticed the failure on https://doi-janky.infosiftr.net/job/repo-info/job/local/job/mariadb/

v3.9 is end of life

Picked 3.13 as latest with version from https://pkgs.alpinelinux.org/package/v3.13/main/x86_64/apk-tools-static