### PR TITLE
Rework gather-rpm script to use `dnf download` on EL8

### DIFF
--- a/.local-scripts/gather-rpm.sh
+++ b/.local-scripts/gather-rpm.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+source /etc/os-release
+MAJOR_VERSION="${VERSION_ID//.*}"
+
 # try rebuilding RPM's database before querying it, just in case (helps with RPM version mismatches)
 rpm --rebuilddb &> /dev/null || :
 
@@ -21,7 +24,9 @@ fi
 IFS=$'\n'
 arches=( $(rpm -qa --queryformat '%{ARCH}\n' 2>/dev/null | sort -u | grep -vE '^noarch|[(]none[)]$') )
 unset IFS
-if [ "${#arches[@]}" -eq 1 ]; then
+
+# EL 8 should not exhibit these systems. If it does, we can write to /etc/dnf/vars/basearch to override where needed instead of adding find as a dep.
+if [[ "$MAJOR_VERSION" -lt 8 && $"${#arches[@]}" -eq 1 ]]; then
 	basearch="${arches[0]}"
 	find /etc/yum.conf /etc/yum.repos.d -type f -exec sed -i 's!\$basearch!'"$basearch"'!g' '{}' +
 fi
@@ -41,6 +46,16 @@ yumDownloaderExtraArgs=()
 # ClefOS has a "source" repo, but for some reason "yumdownloader" isn't smart enough to auto-enable it like it does other source repos?
 if yum repolist disabled 2>/dev/null | grep -qE '^source[[:space:]]+'; then
 	yumDownloaderExtraArgs+=( --enablerepo=source )
+fi
+
+if [[ "${VERSION_ID//.*}" -lt 8 ]]; then # $VERSION_ID from /etc/os-release
+ 	downloadCommand=( "$(command -v yumdownloader)" )
+else
+  	# Download command needs dnf-plugins-core
+ 	if ! rpm -q dnf-plugins-core | grep 'not installed' >/dev/null 2>&1; then
+   		dnf -y install dnf-plugins-core >/dev/null 2>&1
+	fi
+  	downloadCommand=( "$(command -v dnf)" "download" )
 fi
 
 for pkg in "${packages[@]}"; do
@@ -63,15 +78,17 @@ for pkg in "${packages[@]}"; do
 		*) yumPkg="$(rpm --query --queryformat '%{NAME}-%{VERSION}-%{RELEASE}\n' "$pkg" 2>/dev/null)" ;;
 	esac
 
-	yumDownloaderArgs=( yumdownloader --quiet --source --urls "${yumDownloaderExtraArgs[@]}" "$yumPkg" )
-	if yumDownloader="$("${yumDownloaderArgs[@]}" 2>/dev/null)" && [ -n "$yumDownloader" ]; then
-		echo
-		echo 'Source:'
-		echo
-		echo '```console'
-		echo '$' "${yumDownloaderArgs[@]}"
-		echo "$yumDownloader"
-		echo '```'
+        downloadArgs=( "${downloadCommand[@]}" "--quiet" "--source" "--urls" "${yumDownloaderExtraArgs[@]}" "$yumPkg" )
+        sourceUrl="$("${downloadArgs[@]}" 2>/dev/null)"
+
+        if [ -n "$sourceUrl" ]; then
+                echo
+                echo 'Source:'
+                echo
+                echo '```console'
+                echo '$' "${downloadArgs[@]}"
+                echo "$sourceUrl"
+                echo '```'
 	else
 		echo
 		echo '**WARNING:** unable to find source (`yumdownloader` failed or returned no results)!'


### PR DESCRIPTION
Eliminated some checks that should only be applicable to EL7
distributions, as well as sourcing the version number from
/etc/os-release.

`dnf-plugins`core` must be installed for the download command to work,
and to slim down images, it's often not available, so in this case we
install the package silently in the background.