### PR TITLE
Add better support for buildkit-built images

### DIFF
--- a/.remote.pl
+++ b/.remote.pl
@@ -247,6 +247,7 @@ sub cmd_to_dockerfile ($cmd, $shell) {
 		my $nopRegex = "\Q#(nop)\E +";
 
 		my $str = $cmd->[0];
+		$str =~ s!^RUN !!; # strip off "RUN" prefix from buildkit (added back later)
 		my @prefix = ();
 		if ($str =~ s!^[|]\d+ (.*?) ($shellRegex)!$2!) {
 			push @prefix, '# ARGS: ' . $1;
@@ -258,8 +259,8 @@ sub cmd_to_dockerfile ($cmd, $shell) {
 			return '# unable to parse image command string further:' . "\n" . $str;
 		}
 		$str =~ s!^$shellRegex!!;
-		unless ($str =~ s!^$nopRegex!!) {
-			# if we don't have "#(nop)", RUN is implied
+		unless ($str =~ s!^$nopRegex!! || $str =~ m!^[A-Z]+ !) {
+			# if we don't have "#(nop)" or something that looks like an all-caps Dockerfile instruction, RUN is implied
 			$str = 'RUN ' . $str;
 		}
 		return join "\n", @prefix, $str;


### PR DESCRIPTION
Compare https://github.com/docker-library/repo-info/blob/8b96bf18daec8cd5d4f0c3f69b50f79b236be992/repos/kibana/remote/8.4.3.md#kibana843---linux-amd64 to:

---

### `kibana:8.4.3` - linux; amd64

```console
$ docker pull kibana@sha256:5f307a3a79dc3ec84c5b99d363e9b3dc5f859fb4feba57c180ff0a8526b7bc4e
```

-	Manifest MIME: `application/vnd.docker.distribution.manifest.v2+json`
-	Total Size: **342.7 MB (342719349 bytes)**  
	(compressed transfer size, not on-disk size)
-	Image ID: `sha256:b14d91e49f3f9e306570ede88c4b0cf4591b47a0e2d4094fdd86128b75170217`
-	Entrypoint: `["\/bin\/tini","--"]`
-	Default Command: `["\/usr\/local\/bin\/kibana-docker"]`

```dockerfile
# Thu, 01 Sep 2022 23:46:26 GMT
ADD file:ff6963f777661fb16cc12fb04a97c558bd94768a6e4ab5bd90e01f3086818853 in / 
# Thu, 01 Sep 2022 23:46:27 GMT
CMD ["bash"]
# Wed, 28 Sep 2022 11:37:24 GMT
EXPOSE map[5601/tcp:{}]
# Wed, 28 Sep 2022 11:37:24 GMT
RUN for iter in {1..10}; do       export DEBIAN_FRONTEND=noninteractive &&       apt-get update  &&       apt-get upgrade -y  &&       apt-get install -y --no-install-recommends        fontconfig fonts-liberation libnss3 libfontconfig1 ca-certificates curl &&       apt-get clean &&       rm -rf /var/lib/apt/lists/* && exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" &&       sleep 10;     done;     (exit $exit_code) # buildkit
# Wed, 28 Sep 2022 11:37:25 GMT
RUN set -e ;     TINI_BIN="" ;     case "$(arch)" in         aarch64)             TINI_BIN='tini-arm64' ;             ;;         x86_64)             TINI_BIN='tini-amd64' ;             ;;         *) echo >&2 "Unsupported architecture $(arch)" ; exit 1 ;;     esac ;   TINI_VERSION='v0.19.0' ;   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ;   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}.sha256sum" ;   sha256sum -c "${TINI_BIN}.sha256sum" ;   rm "${TINI_BIN}.sha256sum" ;   mv "${TINI_BIN}" /bin/tini ;   chmod +x /bin/tini # buildkit
# Wed, 28 Sep 2022 11:37:25 GMT
RUN mkdir /usr/share/fonts/local # buildkit
# Wed, 28 Sep 2022 11:37:26 GMT
RUN curl --retry 8 -S -L -o /usr/share/fonts/local/NotoSansCJK-Regular.ttc https://github.com/googlefonts/noto-cjk/raw/NotoSansV2.001/NotoSansCJK-Regular.ttc # buildkit
# Wed, 28 Sep 2022 11:37:26 GMT
RUN echo "5dcd1c336cc9344cb77c03a0cd8982ca8a7dc97d620fd6c9c434e02dcb1ceeb3  /usr/share/fonts/local/NotoSansCJK-Regular.ttc" | sha256sum -c - # buildkit
# Wed, 28 Sep 2022 11:37:27 GMT
RUN fc-cache -v # buildkit
# Wed, 28 Sep 2022 11:38:38 GMT
COPY /usr/share/kibana /usr/share/kibana # buildkit
# Wed, 28 Sep 2022 11:38:38 GMT
WORKDIR /usr/share/kibana
# Wed, 28 Sep 2022 11:38:38 GMT
RUN ln -s /usr/share/kibana /opt/kibana # buildkit
# Wed, 28 Sep 2022 11:38:38 GMT
ENV ELASTIC_CONTAINER=true
# Wed, 28 Sep 2022 11:38:38 GMT
ENV PATH=/usr/share/kibana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
# Wed, 28 Sep 2022 11:38:38 GMT
COPY config/kibana.yml /usr/share/kibana/config/kibana.yml # buildkit
# Wed, 28 Sep 2022 11:38:38 GMT
COPY bin/kibana-docker /usr/local/bin/ # buildkit
# Wed, 28 Sep 2022 11:38:39 GMT
RUN chmod g+ws /usr/share/kibana &&     find /usr/share/kibana -gid 0 -and -not -perm /g+w -exec chmod g+w {} \; # buildkit
# Wed, 28 Sep 2022 11:38:40 GMT
RUN find / -xdev -perm -4000 -exec chmod u-s {} + # buildkit
# Wed, 28 Sep 2022 11:38:40 GMT
RUN groupadd --gid 1000 kibana &&     useradd --uid 1000 --gid 1000 -G 0       --home-dir /usr/share/kibana --no-create-home       kibana # buildkit
# Wed, 28 Sep 2022 11:38:40 GMT
LABEL org.label-schema.build-date=2022-09-28T11:09:19.930Z org.label-schema.license=Elastic License org.label-schema.name=Kibana org.label-schema.schema-version=1.0 org.label-schema.url=https://www.elastic.co/products/kibana org.label-schema.usage=https://www.elastic.co/guide/en/kibana/reference/index.html org.label-schema.vcs-ref=1ceb607762eaafa726c61d6eee5b95359142d4c4 org.label-schema.vcs-url=https://github.com/elastic/kibana org.label-schema.vendor=Elastic org.label-schema.version=8.4.3 org.opencontainers.image.created=2022-09-28T11:09:19.930Z org.opencontainers.image.documentation=https://www.elastic.co/guide/en/kibana/reference/index.html org.opencontainers.image.licenses=Elastic License org.opencontainers.image.revision=1ceb607762eaafa726c61d6eee5b95359142d4c4 org.opencontainers.image.source=https://github.com/elastic/kibana org.opencontainers.image.title=Kibana org.opencontainers.image.url=https://www.elastic.co/products/kibana org.opencontainers.image.vendor=Elastic org.opencontainers.image.version=8.4.3
# Wed, 28 Sep 2022 11:38:40 GMT
ENTRYPOINT ["/bin/tini" "--"]
# Wed, 28 Sep 2022 11:38:40 GMT
CMD ["/usr/local/bin/kibana-docker"]
# Wed, 28 Sep 2022 11:38:40 GMT
USER kibana
```