### PR TITLE
Use gawk explicitly to avoid /etc/alternatives symlink

### DIFF
--- a/.local-scripts/gather-dpkg.sh
+++ b/.local-scripts/gather-dpkg.sh
@@ -99,7 +99,7 @@ for src in "${sortedSources[@]}"; do
 			continue
 		fi
 		IFS=$'\n'
-		licenses+=( $(awk -F ':[ \t]+' '$1 == "License" && NF > 1 { gsub(/^License:[ \t]+/, ""); print }' "$f") )
+		licenses+=( $(gawk -F ':[ \t]+' '$1 == "License" && NF > 1 { gsub(/^License:[ \t]+/, ""); print }' "$f") )
 		licenses+=( $(grep -oE '/usr/share/common-licenses/[0-9a-zA-Z_.+-]+' "$f" | cut -d/ -f5-) )
 		unset IFS
 		licenseFiles+=( "$f" )

--- a/Dockerfile.local-dpkg
+++ b/Dockerfile.local-dpkg
@@ -4,6 +4,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
+		gawk \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This should fix scanning of images that don't have an `/etc/alternatives/awk` symlink (since `/etc` is mounted over from the image to be scanned)

```console
+ ./scan-local.sh mariadb:11.3.1-rc-jammy
W: Skipping acquire of configured file 'main/debug/source/Sources' as repository 'http://archive.mariadb.org/mariadb-11.3.1/repo/ubuntu jammy InRelease' does not seem to provide it (sources.list entry misspelt?)
/usr/local/bin/gather-dpkg.sh: line 102: awk: command not found
```

(It has been broken for, a while: https://github.com/docker-library/repo-info/commit/f253803218f6f922a77b68f32f5c26fa2f82f7a0)