### PR TITLE
Fix scan-local to have access to keyrings

### DIFF
--- a/scan-local.sh
+++ b/scan-local.sh
@@ -19,6 +19,7 @@ docker create \
 	-v /usr/lib/rpm \
 	-v /usr/share/apk \
 	-v /usr/share/doc \
+	-v /usr/share/keyrings \
 	-v /var/lib \
 	"$image" \
 	bogus > /dev/null


### PR DESCRIPTION
This causes some of our repo-info pages to be blank.  We should probably add a test for that.  :see_no_evil: