### PR TITLE
scan-local.sh move to jq

### DIFF
--- a/Dockerfile.local-apk
+++ b/Dockerfile.local-apk
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.24
 
 RUN apk add --no-cache bash
 

--- a/Dockerfile.local-dpkg
+++ b/Dockerfile.local-dpkg
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 RUN set -eux; \
 	apt-get update; \
@@ -7,7 +7,7 @@ RUN set -eux; \
 		gawk \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean
 
 COPY .local-scripts/gather-dpkg.sh /usr/local/bin/
 

--- a/Dockerfile.local-rpm
+++ b/Dockerfile.local-rpm
@@ -1,4 +1,4 @@
-FROM oraclelinux:8
+FROM oraclelinux:10
 
 COPY .local-scripts/gather-rpm.sh /usr/local/bin/
 

--- a/scan-local.sh
+++ b/scan-local.sh
@@ -26,35 +26,49 @@ docker create \
 
 echo '# `'"$image"'`'
 
-size="$(
-	docker inspect -f '{{ if index . "VirtualSize" }}{{ .VirtualSize }}{{ else }}{{ .Size }}{{ end }}' "$image" | awk '{
-		oneKb = 1000;
-		oneMb = 1000 * oneKb;
-		oneGb = 1000 * oneMb;
-		if ($1 >= oneGb) {
-			printf "~ %.2f Gb", $1 / oneGb
-		} else if ($1 >= oneMb) {
-			printf "~ %.2f Mb", $1 / oneMb
-		} else if ($1 >= oneKb) {
-			printf "~ %.2f Kb", $1 / oneKb
-		} else {
-			printf "%d bytes", $1
-		}
-	}'
-)"
-
-docker inspect -f '
-## Docker Metadata
-
-- Image ID: `{{ .Id }}`
-- Created: `{{ .Created }}`
-- Virtual Size: '"$size"'  
-  (total size of all layers on-disk)
-- Arch: `{{ .Os }}`/`{{ .Architecture }}`
-{{ if index .Config "Entrypoint" }}- Entrypoint: `{{ json .Config.Entrypoint }}`
-{{ end }}{{ if index .Config "Cmd" }}- Command: `{{ json .Config.Cmd }}`
-{{ end }}- Environment:{{ range .Config.Env }}{{ "\n" }}  - `{{ . }}`{{ end }}{{ if .Config.Labels }}
-- Labels:{{ range $k, $v := .Config.Labels }}{{ "\n" }}  - `{{ $k }}={{ $v }}`{{ end }}{{ end }}' "$image"
+docker inspect -f 'json' "$image" | jq --raw-output '
+	.[] # docker inspect returns a list of inspections
+	| [
+		"## Docker Metadata",
+		"",
+		"- Image ID: `\( .Id // .ID )`",
+		"- Created: `\( .Created )`",
+		"- Virtual Size: \(
+			def twoDecimals:
+				. * 100 | round / 100
+			;
+			.VirtualSize // .Size
+			| tonumber
+			| 1000 as $oneKb
+			| (1000 * $oneKb) as $oneMb
+			| (1000 * $oneMb) as $oneGb
+			| if . >= $oneGb then
+				"~ \( . / $oneGb | twoDecimals ) Gb"
+			elif . >= $oneMb then
+				"~ \( . / $oneMb | twoDecimals ) Mb"
+			elif . >= $oneKb then
+				"~ \( . / $oneKb | twoDecimals ) Kb"
+			else
+				"\(.) bytes"
+			end
+		)",
+		"  (total size of all layers on-disk)",
+		"- Arch: `\( .Os )`/`\( .Architecture )`",
+		if .Config.Entrypoint then
+			"- Entrypoint: `\( .Config.Entrypoint )`"
+		else empty end,
+		if .Config.Cmd then
+			"- Command: `\( .Config.Cmd )`"
+		else empty end,
+		"- Environment:",
+		( .Config.Env.[] | "  - `\( . )`" ),
+		if .Config.Labels then
+			"- Labels:",
+			( .Config.Labels | to_entries[] | "  - `\( .key )=\( .value )`" )
+		else empty end,
+		empty
+	] | join("\n")
+'
 
 docker run --rm --volumes-from "$name-data" -v /etc/ssl repo-info:local-apk || :
 docker run --rm --volumes-from "$name-data" -v /etc/ssl repo-info:local-dpkg || :


### PR DESCRIPTION
Docker's text template has strange behavior on newer Docker APIs when inspecting images without labels, so this moves to `jq` to avoid it altogether. This also bumps the OS versions of the scanning images.

---

```console
$ docker inspect -f '{{ .Id }} {{ if .Config.Labels }}foo{{ else }}bar{{ end }}' alpine

template parsing error: template: :1:23: executing "" at <.Config.Labels>: map has no entry for key "Labels"
```

It was narrowed down to the 1.52 API version (even on older docker clients):
```console
$ docker run -it --rm -e DOCKER_API_VERSION=1.52 -v /var/run/docker.sock:/var/run/docker.sock docker:28.5.2-cli docker inspect -f '{{ .Id }} {{ if .Config.Labels }}foo{{ else }}bar{{ end }}' alpine

template parsing error: template: :1:23: executing "" at <.Config.Labels>: map has no entry for key "Labels"

$ docker run -it --rm -e DOCKER_API_VERSION=1.51 -v /var/run/docker.sock:/var/run/docker.sock docker:28.5.2-cli docker inspect -f '{{ .Id }} {{ if .Config.Labels }}foo{{ else }}bar{{ end }}' alpine
sha256:fa1b3b8cd12d2b2ded5ef366f99b5a7556884646af680404989d626535a3ac14 bar
```

And doesn't break if `ID` is used instead of the older `Id`:
```console
$ docker run -it --rm -e DOCKER_API_VERSION=1.52 -v /var/run/docker.sock:/var/run/docker.sock docker:28.5.2-cli docker inspect -f '{{ .ID }} {{ if .Config.Labels }}foo{{ else }}bar{{ end }}' alpine
sha256:fa1b3b8cd12d2b2ded5ef366f99b5a7556884646af680404989d626535a3ac14 bar
$ docker run -it --rm -e DOCKER_API_VERSION=1.51 -v /var/run/docker.sock:/var/run/docker.sock docker:28.5.2-cli docker inspect -f '{{ .ID }} {{ if .Config.Labels }}foo{{ else }}bar{{ end }}' alpine
sha256:fa1b3b8cd12d2b2ded5ef366f99b5a7556884646af680404989d626535a3ac14 bar
```